### PR TITLE
fix: Add a parameterless constructor to avoid deserialization errors

### DIFF
--- a/src/Core/CreatedGuid.cs
+++ b/src/Core/CreatedGuid.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public sealed class CreatedGuid
 {
-    internal CreatedGuid() { }
+    public CreatedGuid() { }
 
     public string Id { get; init; }
 }

--- a/src/Core/CreatedId.cs
+++ b/src/Core/CreatedId.cs
@@ -5,7 +5,7 @@
 /// </summary>
 public sealed class CreatedId
 {
-    internal CreatedId() { }
+    public CreatedId() { }
 
     public int Id { get; init; }
 }

--- a/src/Core/Result.cs
+++ b/src/Core/Result.cs
@@ -6,7 +6,7 @@
 /// <remarks>This class defines different types of results for an operation.</remarks>
 public sealed class Result : ResultBase
 {
-    internal Result() { }
+    public Result() { }
 
     /// <inheritdoc cref="Success{T}(T, string)" />
     public static Result<T> Success<T>(T data)

--- a/src/Core/ResultOfT.cs
+++ b/src/Core/ResultOfT.cs
@@ -4,7 +4,7 @@
 /// <inheritdoc cref="ResultBase" />
 public sealed class Result<T> : ResultBase
 {
-    internal Result() { }
+    public Result() { }
 
     /// <summary>
     /// Gets the data associated with the result.

--- a/tests/GlobalUsings.cs
+++ b/tests/GlobalUsings.cs
@@ -1,4 +1,5 @@
 global using System.Globalization;
+global using System.Text.Json;
 global using NUnit.Framework;
 global using FluentAssertions;
 global using Microsoft.AspNetCore.Mvc;

--- a/tests/SystemTextJson.Result.Tests.cs
+++ b/tests/SystemTextJson.Result.Tests.cs
@@ -1,0 +1,48 @@
+﻿namespace SimpleResults.Tests;
+
+public class SystemTextJsonResult
+{
+    [Test]
+    public void Result_ShouldSerializeResultWithoutData()
+    {
+        // Arrange
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        Result result = Result.Success();
+        var expectedJson =
+            $$"""
+            {
+              "success": true,
+              "message": "{{ResponseMessages.Success}}",
+              "errors": []
+            }
+            """;
+
+        // Act
+        var actual = JsonSerializer.Serialize(result, options);
+
+        // Assert
+        actual.Should().BeEquivalentTo(expectedJson);
+    }
+
+    [Test]
+    public void Result_ShouldDeserializeResultWithoutData()
+    {
+        // Arrange
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        Result expectedResult = Result.Success();
+        var json =
+            $$"""
+            {
+              "success": true,
+              "message": "{{ResponseMessages.Success}}",
+              "errors": []
+            }
+            """;
+
+        // Act
+        var actual = JsonSerializer.Deserialize<Result>(json, options);
+
+        // Assert
+        actual.Should().BeEquivalentTo(expectedResult);
+    }
+}

--- a/tests/SystemTextJson.ResultOfT.Tests.cs
+++ b/tests/SystemTextJson.ResultOfT.Tests.cs
@@ -1,0 +1,126 @@
+﻿namespace SimpleResults.Tests;
+
+public class SystemTextJsonResultOfT
+{
+    [Test]
+    public void ResultOfT_ShouldSerializeResultOfValueType()
+    {
+        // Arrange
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        Result<int> result = Result.Success(1);
+        var expectedJson =
+            $$"""
+            {
+              "data": 1,
+              "success": true,
+              "message": "{{ResponseMessages.Success}}",
+              "errors": []
+            }
+            """;
+
+        // Act
+        var actual = JsonSerializer.Serialize(result, options);
+
+        // Assert
+        actual.Should().BeEquivalentTo(expectedJson);
+    }
+
+    [Test]
+    public void ResultOfT_ShouldSerializeResultOfReferenceType()
+    {
+        // Arrange
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        Result<Person> result = Result.Success(new Person { Name = "Test" });
+        var expectedJson =
+            $$"""
+            {
+              "data": {
+                "name": "Test"
+              },
+              "success": true,
+              "message": "{{ResponseMessages.Success}}",
+              "errors": []
+            }
+            """;
+
+        // Act
+        var actual = JsonSerializer.Serialize(result, options);
+
+        // Assert
+        actual.Should().BeEquivalentTo(expectedJson);
+    }
+
+    [Test]
+    public void ResultOfT_ShouldDeserializeResultOfValueType()
+    {
+        // Arrange
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        Result<int> expectedResult = Result.Success(1);
+        var json =
+            $$"""
+            {
+              "data": 1,
+              "success": true,
+              "message": "{{ResponseMessages.Success}}",
+              "errors": []
+            }
+            """;
+
+        // Act
+        var actual = JsonSerializer.Deserialize<Result<int>>(json, options);
+
+        // Assert
+        actual.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Test]
+    public void ResultOfT_ShouldDeserializeResultOfCreatedIdType()
+    {
+        // Arrange
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        Result<CreatedId> expectedResult = Result.Success(new CreatedId { Id = 1 } );
+        var json =
+            $$"""
+            {
+              "data": {
+                "Id": 1
+              },
+              "success": true,
+              "message": "{{ResponseMessages.Success}}",
+              "errors": []
+            }
+            """;
+
+        // Act
+        var actual = JsonSerializer.Deserialize<Result<CreatedId>>(json, options);
+
+        // Assert
+        actual.Should().BeEquivalentTo(expectedResult);
+    }
+
+    [Test]
+    public void ResultOfT_ShouldDeserializeResultOfCreatedGuidType()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        Result<CreatedGuid> expectedResult = Result.Success(new CreatedGuid { Id = guid.ToString() });
+        var json =
+            $$"""
+            {
+              "data": {
+                "Id": "{{guid}}"
+              },
+              "success": true,
+              "message": "{{ResponseMessages.Success}}",
+              "errors": []
+            }
+            """;
+
+        // Act
+        var actual = JsonSerializer.Deserialize<Result<CreatedGuid>>(json, options);
+
+        // Assert
+        actual.Should().BeEquivalentTo(expectedResult);
+    }
+}


### PR DESCRIPTION
This change fixes this exception:
`System.NotSupportedException` : Deserialization of types without a parameterless constructor, a singular parameterized constructor, or a parameterized constructor annotated with 'JsonConstructorAttribute' is not supported.