### PR TITLE
refactor: Assign an empty `IEnumerable<T>` to the Result.Data property

### DIFF
--- a/src/Core/ListedResultOfT.cs
+++ b/src/Core/ListedResultOfT.cs
@@ -11,7 +11,7 @@ public sealed class ListedResult<T> : ResultBase
     /// <summary>
     /// Gets a list of data associated with the result.
     /// </summary>
-    public IEnumerable<T> Data { get; init; }
+    public IEnumerable<T> Data { get; init; } = Enumerable.Empty<T>();
 
     private static ListedResult<T> CreateInstance(ResultBase result, IEnumerable<T> data) => new()
     {

--- a/src/Core/PagedResultOfT.cs
+++ b/src/Core/PagedResultOfT.cs
@@ -11,7 +11,7 @@ public sealed class PagedResult<T> : ResultBase
     /// <summary>
     /// Gets the data from a page.
     /// </summary>
-    public IEnumerable<T> Data { get; init; }
+    public IEnumerable<T> Data { get; init; } = Enumerable.Empty<T>();
 
     /// <summary>
     /// Gets information about the page.

--- a/tests/ListedResultOfT.Tests.cs
+++ b/tests/ListedResultOfT.Tests.cs
@@ -3,6 +3,19 @@
 public class ListedResultOfTTests
 {
     [Test]
+    public void ListedResultOfT_ShouldCreateInstanceWithDefaultValues()
+    {
+        // Act
+        var actual = new ListedResult<Person>();
+
+        // Asserts
+        actual.Data.Should().BeEmpty();
+        actual.IsSuccess.Should().BeFalse();
+        actual.IsFailed.Should().BeTrue();
+        actual.Errors.Should().BeEmpty();
+    }
+
+    [Test]
     public void ImplicitOperator_WhenConvertedFromResultType_ShouldReturnsListedResultOfT()
     {
         // Arrange

--- a/tests/PagedResultOfT.Tests.cs
+++ b/tests/PagedResultOfT.Tests.cs
@@ -3,6 +3,20 @@
 public class PagedResultOfTTests
 {
     [Test]
+    public void PagedResultOfT_ShouldCreateInstanceWithDefaultValues()
+    {
+        // Act
+        var actual = new PagedResult<Person>();
+
+        // Asserts
+        actual.Data.Should().BeEmpty();
+        actual.PagedInfo.Should().BeNull();
+        actual.IsSuccess.Should().BeFalse();
+        actual.IsFailed.Should().BeTrue();
+        actual.Errors.Should().BeEmpty();
+    }
+
+    [Test]
     public void ImplicitOperator_WhenConvertedFromResultType_ShouldReturnsPagedResultOfT()
     {
         // Arrange


### PR DESCRIPTION
This avoids a possible **NullReferenceException** when accessing the Data property of Result object.