### PR TITLE
fix!: Incorrect status is obtained when deserializing the result object

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,14 +4,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="FluentValidation" Version="10.0.4" />
-    <PackageVersion Include="System.Text.Json" Version="4.6.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.0" />
     <PackageVersion Include="IsExternalInit" Version="1.0.3" />
     <PackageVersion Include="Bogus" Version="34.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="7.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.10.0" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.3.0" />

--- a/samples/SimpleResults.Example.AspNetCore/GlobalUsings.cs
+++ b/samples/SimpleResults.Example.AspNetCore/GlobalUsings.cs
@@ -1,4 +1,5 @@
 ﻿global using System.Net.Mime;
+global using System.Text.Json.Serialization;
 global using Bogus;
 global using Microsoft.AspNetCore.Mvc;
 global using Swashbuckle.AspNetCore.Annotations;

--- a/samples/SimpleResults.Example.AspNetCore/Program.cs
+++ b/samples/SimpleResults.Example.AspNetCore/Program.cs
@@ -15,10 +15,15 @@ builder.Services.AddControllers(options =>
     // Add filter for all controllers.
     options.Filters.Add<TranslateResultToActionResultAttribute>();
 })
+.AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter<ResultStatus>());
+})
 .ConfigureApiBehaviorOptions(options =>
 {
     options.InvalidModelStateResponseFactory = (context) => context.ModelState.BadRequest();
 });
+
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>

--- a/samples/SimpleResults.Example.Web.Tests/Features/CreateOrderTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/CreateOrderTests.cs
@@ -38,6 +38,7 @@ public class CreateOrderTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Created);
     }
 
     [TestCase(Routes.Order.ManualValidation)]
@@ -95,5 +96,6 @@ public class CreateOrderTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEquivalentTo(expectedErrors);
+        result.Status.Should().Be(ResultStatus.Invalid);
     }
 }

--- a/samples/SimpleResults.Example.Web.Tests/Features/CreatePersonTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/CreatePersonTests.cs
@@ -26,6 +26,7 @@ public class CreatePersonTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Created);
     }
 
     [TestCase(Routes.Person.WebApi)]
@@ -52,5 +53,6 @@ public class CreatePersonTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().NotBeNullOrEmpty();
+        result.Status.Should().Be(ResultStatus.Invalid);
     }
 }

--- a/samples/SimpleResults.Example.Web.Tests/Features/CreateUserTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/CreateUserTests.cs
@@ -23,6 +23,7 @@ public class CreateUserTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Created);
     }
 
     [TestCase(Routes.User.WebApi)]
@@ -46,5 +47,6 @@ public class CreateUserTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Invalid);
     }
 }

--- a/samples/SimpleResults.Example.Web.Tests/Features/DeleteUserTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/DeleteUserTests.cs
@@ -23,6 +23,7 @@ public class DeleteUserTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Ok);
     }
 
     [TestCase(Routes.User.WebApi)]
@@ -44,5 +45,6 @@ public class DeleteUserTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.NotFound);
     }
 }

--- a/samples/SimpleResults.Example.Web.Tests/Features/GetFileResultTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/GetFileResultTests.cs
@@ -47,5 +47,6 @@ public class GetFileResultTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Invalid);
     }
 }

--- a/samples/SimpleResults.Example.Web.Tests/Features/GetMessageTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/GetMessageTests.cs
@@ -21,6 +21,7 @@ public class GetMessageTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Forbidden);
     }
 
     [TestCase(Routes.Message.WebApi)]
@@ -42,6 +43,7 @@ public class GetMessageTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.CriticalError);
     }
 
     [TestCase(Routes.Message.WebApi)]
@@ -63,5 +65,6 @@ public class GetMessageTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Unauthorized);
     }
 }

--- a/samples/SimpleResults.Example.Web.Tests/Features/GetPagedUsersTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/GetPagedUsersTests.cs
@@ -24,6 +24,7 @@ public class GetPagedUsersTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Ok);
     }
 
     [TestCase(Routes.User.WebApi)]
@@ -48,6 +49,7 @@ public class GetPagedUsersTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Failure);
     }
 
     [TestCase(Routes.User.WebApi)]
@@ -72,5 +74,6 @@ public class GetPagedUsersTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Invalid);
     }
 }

--- a/samples/SimpleResults.Example.Web.Tests/Features/GetPersonsTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/GetPersonsTests.cs
@@ -24,6 +24,7 @@ public class GetPersonsTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Ok);
     }
 
     [TestCase(Routes.Person.WebApi)]
@@ -48,5 +49,6 @@ public class GetPersonsTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Failure);
     }
 }

--- a/samples/SimpleResults.Example.Web.Tests/Features/GetUserByIdTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/GetUserByIdTests.cs
@@ -24,6 +24,7 @@ public class GetUserByIdTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Ok);
     }
 
     [TestCase(Routes.User.WebApi)]
@@ -46,5 +47,6 @@ public class GetUserByIdTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.NotFound);
     }
 }

--- a/samples/SimpleResults.Example.Web.Tests/Features/GetUsersTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/GetUsersTests.cs
@@ -22,6 +22,7 @@ public class GetUsersTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Ok);
     }
 
     [TestCase(Routes.User.WebApi)]
@@ -46,5 +47,6 @@ public class GetUsersTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Failure);
     }
 }

--- a/samples/SimpleResults.Example.Web.Tests/Features/UpdateUserTests.cs
+++ b/samples/SimpleResults.Example.Web.Tests/Features/UpdateUserTests.cs
@@ -24,6 +24,7 @@ public class UpdateUserTests
         result.IsSuccess.Should().BeTrue();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Ok);
     }
 
     [TestCase(Routes.User.WebApi)]
@@ -46,6 +47,7 @@ public class UpdateUserTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.NotFound);
     }
 
     [TestCase(Routes.User.WebApi)]
@@ -68,5 +70,6 @@ public class UpdateUserTests
         result.IsSuccess.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.Errors.Should().BeEmpty();
+        result.Status.Should().Be(ResultStatus.Invalid);
     }
 }

--- a/src/Core/ResultBase.cs
+++ b/src/Core/ResultBase.cs
@@ -11,6 +11,16 @@ namespace SimpleResults;
 public abstract class ResultBase
 {
     /// <summary>
+    /// Gets the current status of a result.
+    /// </summary>
+    /// <value>
+    /// The current status of a result.
+    /// Its default value is a <see cref="ResultStatus.Failure"/>.
+    /// </value>
+    [JsonConverter(typeof(JsonStringEnumConverter<ResultStatus>))]
+    public ResultStatus Status { get; init; } = ResultStatus.Failure;
+
+    /// <summary>
     /// A value indicating that the result was successful.
     /// </summary>
     [JsonPropertyName("success")]
@@ -39,14 +49,4 @@ public abstract class ResultBase
     /// Its default value is never a null value.
     /// </value>
     public IEnumerable<string> Errors { get; init; } = Enumerable.Empty<string>();
-
-    /// <summary>
-    /// Gets the current status of a result.
-    /// </summary>
-    /// <value>
-    /// The current status of a result.
-    /// Its default value is a <see cref="ResultStatus.Failure"/>.
-    /// </value>
-    [JsonIgnore]
-    public ResultStatus Status { get; init; } = ResultStatus.Failure;
 }

--- a/tests/Core/Json/SystemTextJson.ListedResultOfT.Tests.cs
+++ b/tests/Core/Json/SystemTextJson.ListedResultOfT.Tests.cs
@@ -16,6 +16,7 @@ public class SystemTextJsonListedResultOfT
                 1,
                 2
               ],
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -51,6 +52,7 @@ public class SystemTextJsonListedResultOfT
                   "name": "Alice"
                 }
               ],
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -78,6 +80,7 @@ public class SystemTextJsonListedResultOfT
                 1,
                 2
               ],
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -88,9 +91,7 @@ public class SystemTextJsonListedResultOfT
         var actual = JsonSerializer.Deserialize<ListedResult<int>>(json, options);
 
         // Assert
-        actual
-            .Should()
-            .BeEquivalentTo(expectedResult, o => o.Excluding(r => r.Status));
+        actual.Should().BeEquivalentTo(expectedResult);
     }
 
     [Test]
@@ -115,6 +116,7 @@ public class SystemTextJsonListedResultOfT
                   "name": "Alice"
                 }
               ],
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -125,8 +127,6 @@ public class SystemTextJsonListedResultOfT
         var actual = JsonSerializer.Deserialize<ListedResult<Person>>(json, options);
 
         // Assert
-        actual
-            .Should()
-            .BeEquivalentTo(expectedResult, o => o.Excluding(r => r.Status));
+        actual.Should().BeEquivalentTo(expectedResult);
     }
 }

--- a/tests/Core/Json/SystemTextJson.PagedResultOfT.Tests.cs
+++ b/tests/Core/Json/SystemTextJson.PagedResultOfT.Tests.cs
@@ -26,6 +26,7 @@ public class SystemTextJsonPagedResultOfT
                 "hasPrevious": false,
                 "hasNext": true
               },
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.ObtainedResources}}",
               "errors": []
@@ -70,6 +71,7 @@ public class SystemTextJsonPagedResultOfT
                 "hasPrevious": false,
                 "hasNext": true
               },
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.ObtainedResources}}",
               "errors": []
@@ -107,6 +109,7 @@ public class SystemTextJsonPagedResultOfT
                 "hasPrevious": false,
                 "hasNext": true
               },
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.ObtainedResources}}",
               "errors": []
@@ -117,9 +120,7 @@ public class SystemTextJsonPagedResultOfT
         var actual = JsonSerializer.Deserialize<PagedResult<int>>(json, options);
 
         // Assert
-        actual
-            .Should()
-            .BeEquivalentTo(expectedResult, o => o.Excluding(r => r.Status));
+        actual.Should().BeEquivalentTo(expectedResult);
     }
 
     [Test]
@@ -153,6 +154,7 @@ public class SystemTextJsonPagedResultOfT
                 "hasPrevious": false,
                 "hasNext": true
               },
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.ObtainedResources}}",
               "errors": []
@@ -163,8 +165,6 @@ public class SystemTextJsonPagedResultOfT
         var actual = JsonSerializer.Deserialize<PagedResult<Person>>(json, options);
 
         // Assert
-        actual
-            .Should()
-            .BeEquivalentTo(expectedResult, o => o.Excluding(r => r.Status));
+        actual.Should().BeEquivalentTo(expectedResult);
     }
 }

--- a/tests/Core/Json/SystemTextJson.Result.Tests.cs
+++ b/tests/Core/Json/SystemTextJson.Result.Tests.cs
@@ -11,6 +11,7 @@ public class SystemTextJsonResult
         var expectedJson =
             $$"""
             {
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -33,6 +34,7 @@ public class SystemTextJsonResult
         var json =
             $$"""
             {
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -43,8 +45,6 @@ public class SystemTextJsonResult
         var actual = JsonSerializer.Deserialize<Result>(json, options);
 
         // Assert
-        actual
-            .Should()
-            .BeEquivalentTo(expectedResult, o => o.Excluding(r => r.Status));
+        actual.Should().BeEquivalentTo(expectedResult);
     }
 }

--- a/tests/Core/Json/SystemTextJson.ResultOfT.Tests.cs
+++ b/tests/Core/Json/SystemTextJson.ResultOfT.Tests.cs
@@ -12,6 +12,7 @@ public class SystemTextJsonResultOfT
             $$"""
             {
               "data": 1,
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -37,6 +38,7 @@ public class SystemTextJsonResultOfT
               "data": {
                 "name": "Test"
               },
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -60,6 +62,7 @@ public class SystemTextJsonResultOfT
             $$"""
             {
               "data": 1,
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -70,9 +73,7 @@ public class SystemTextJsonResultOfT
         var actual = JsonSerializer.Deserialize<Result<int>>(json, options);
 
         // Assert
-        actual
-            .Should()
-            .BeEquivalentTo(expectedResult, o => o.Excluding(r => r.Status));
+        actual.Should().BeEquivalentTo(expectedResult);
     }
 
     [Test]
@@ -87,6 +88,7 @@ public class SystemTextJsonResultOfT
               "data": {
                 "Id": 1
               },
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -97,9 +99,7 @@ public class SystemTextJsonResultOfT
         var actual = JsonSerializer.Deserialize<Result<CreatedId>>(json, options);
 
         // Assert
-        actual
-            .Should()
-            .BeEquivalentTo(expectedResult, o => o.Excluding(r => r.Status));
+        actual.Should().BeEquivalentTo(expectedResult);
     }
 
     [Test]
@@ -115,6 +115,7 @@ public class SystemTextJsonResultOfT
               "data": {
                 "Id": "{{guid}}"
               },
+              "status": "Ok",
               "success": true,
               "message": "{{ResponseMessages.Success}}",
               "errors": []
@@ -125,8 +126,6 @@ public class SystemTextJsonResultOfT
         var actual = JsonSerializer.Deserialize<Result<CreatedGuid>>(json, options);
 
         // Assert
-        actual
-            .Should()
-            .BeEquivalentTo(expectedResult, o => o.Excluding(r => r.Status));
+        actual.Should().BeEquivalentTo(expectedResult);
     }
 }


### PR DESCRIPTION
Resolves #65

- `System.Text.Json` has been updated to 8.0.0 to be able to use the [JsonStringEnumConverter{TEnum}](https://learn.microsoft.com/en-us/dotnet/api/system.text.json.serialization.jsonstringenumconverter-1) type (this is compatible with native AOT).