### PR TITLE
fix: lock FluentAssertions version to 7.x to prevent unintended upgrade

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.10.0" />
+    <PackageVersion Include="FluentAssertions" Version="[7.0.0,8.0.0)" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.3.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="3.5.0" />


### PR DESCRIPTION
[FluentAssertions](https://github.com/fluentassertions/fluentassertions) became a paid library starting from version 8.0 and is no longer open source. This PR is created to prevent unintended upgrades to version 8.

For more details: https://github.com/fluentassertions/fluentassertions/pull/2943
Reference: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges