### PR TITLE
Remove implicit conversion from Result<T> class

### DIFF
--- a/src/Core/ResultOfT.cs
+++ b/src/Core/ResultOfT.cs
@@ -42,11 +42,4 @@ public sealed class Result<T> : ResultBase
         Message = ResponseMessages.Success,
         Status = ResultStatus.Ok
     };
-
-    /// <summary>
-    /// Converts an instance of type <see cref="Result{T}"/> to the value of type <typeparamref name="T"/>.
-    /// </summary>
-    /// <param name="result">An instance of type <see cref="Result{T}"/>.</param>
-    public static implicit operator T(Result<T> result) 
-        => result.Data;
 }

--- a/tests/Core/ResultOfT.Tests.cs
+++ b/tests/Core/ResultOfT.Tests.cs
@@ -60,22 +60,4 @@ public class ResultOfTTests
         actual.Errors.Should().BeEmpty();
         actual.Status.Should().Be(ResultStatus.Ok);
     }
-
-    [Test]
-    public void ImplicitOperator_WhenConvertedFromResultOfT_ShouldReturnsValueOfT()
-    {
-        // Arrange
-        var expectedValue = new List<Person>
-        {
-            new() { Name = "Bob" },
-            new() { Name = "Alice" }
-        };
-        Result<List<Person>> result = Result.Success(expectedValue);
-
-        // Act
-        List<Person> actual = result;
-
-        // Assert
-        actual.Should().BeEquivalentTo(expectedValue);
-    }
 }


### PR DESCRIPTION
The implicit conversion operator to type T has been removed from the Result<T> class, along with its XML documentation comments. This change affects how instances of Result<T> are used in the codebase.

Additionally, the corresponding unit test in ResultOfTTests that verified this conversion has also been removed, reflecting the removal of the conversion functionality.